### PR TITLE
docs: add repository readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # hyb_imaging
+
+Utilities for exploring hybridization imaging data. The repository provides
+Snakemake pipelines and Jupyter notebooks for segmenting images and analyzing results.
+
+## Repository structure
+
+- **pipelines/** – reproducible workflows built with [Snakemake](https://snakemake.readthedocs.io/).
+- **notebooks/** – example notebooks used to validate pipelines and inspect results.
+
+See the README in each directory for details.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE).

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,9 @@
+# Notebooks
+
+Example Jupyter notebooks for exploring hybridization imaging data and pipeline
+outputs.
+
+- `test.ipynb` – quick checks and experiments.
+- `test_segmentation_results.ipynb` – inspect results produced by the segmentation pipeline.
+
+Launch with Jupyter Lab or any compatible notebook interface.

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,0 +1,9 @@
+# Pipelines
+
+This directory contains reproducible workflows implemented with Snakemake.
+
+Available pipelines:
+
+- **segmentation/** – workflow for extracting cell segments from hybridization images.
+
+Refer to each subdirectory for detailed instructions.

--- a/pipelines/segmentation/README.md
+++ b/pipelines/segmentation/README.md
@@ -1,5 +1,13 @@
-# RUN WITH 
+# Segmentation Pipeline
 
-```
+Snakemake workflow for segmenting hybridization imaging data.
+
+## Usage
+
+Run the pipeline from this directory:
+
+```bash
 snakemake --cores 1 --use-conda --drop-metadata --verbose
 ```
+
+Configuration files live in `config/` and custom scripts in `scripts/`.

--- a/pipelines/segmentation/config/README.md
+++ b/pipelines/segmentation/config/README.md
@@ -1,0 +1,6 @@
+# Configuration
+
+Parameters for the segmentation pipeline.
+
+- `config.yaml` – core settings for Snakemake rules.
+- `inputs.txt` – list of input image paths.

--- a/pipelines/segmentation/scripts/README.md
+++ b/pipelines/segmentation/scripts/README.md
@@ -1,0 +1,6 @@
+# Scripts
+
+Utility scripts used by the segmentation pipeline.
+
+- `get_metadata.py` – extracts OME-TIFF metadata into JSON.
+- `segment.py` – stub segmentation implementation used by the workflow.


### PR DESCRIPTION
## Summary
- expand root README with project overview and structure
- add focused READMEs for notebooks and Snakemake pipelines
- document configuration and helper scripts in the segmentation workflow

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a471de3f488331bb2e0e5cfc2da39f